### PR TITLE
Add support for setting desk name

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -7,46 +7,55 @@ from bleak.backends.device import BLEDevice
 
 from uplift import Desk, discover
 
-primary_service_uuid_for_discovery  = normalize_uuid_16(0xfe60)
 
 timeout = 10.0
+
 
 def print_command_options():
 
     print("Commands:")
     print("    h - print this help message")
+    print("    n - read_device_name")
+    print("    w - write_device_name")
     print("    u - move_to_standing")
     print("    d - move_to_sitting")
     print("    r - press_raise")
     print("    l - press_lower")
     print("    e - exit")
 
-async def async_height_notify_callback(desk: Desk):
+
+async def async_notify_callback_device_name(desk: Desk):
+    print(f"Received device name update")
+
+
+async def async_notify_callback_height(desk: Desk):
     print(f"Received height update: {desk.height}; Moving: {desk.moving}")
 
+
 async def main():
+    print("Attempting to discover desks...")
     desks: list[BLEDevice] = await discover()
     if len(desks) == 0:
         print("No desks found")
         return
     print(f"Found {len(desks)} desk(s)")
     for desk in desks:
-        print(f"    - {desk.name} - {desk.address}")       
+        print(f"    - {desk.name} - {desk.address}")
 
     first_desk = desks[0]
     print(f"Connecting to {first_desk.name} - {first_desk.address}...")
 
     async with BleakClient(first_desk) as bleak_client:
         print(f"Connected to {bleak_client.address}")
-        
+
         desk = Desk(first_desk.address, first_desk.name, bleak_client)
 
-        desk.register_callback(async_height_notify_callback)
+        desk.register_callback_desk_name(async_notify_callback_device_name)
+        desk.register_callback_height(async_notify_callback_height)
 
         await desk.start_notify()
         await desk.read_height(bleak_client)
         print(f"Height: {desk.height} in")
-        
         print("Start typing and press ENTER...\n Press h for help")
 
         loop = asyncio.get_running_loop()
@@ -58,26 +67,34 @@ async def main():
             if not data:
                 break
 
-            if (data == b"u\n"):
+            if data == b"n\n":
+                print("read_device_name")
+                await desk.read_device_name()
+            if data == b"w\n":
+                print("write_device_name")
+                name = input("Enter new device name: ")
+                await desk.write_desk_name(bleak_client=None, desk_name=name)
+            if data == b"u\n":
                 print("move_to_standing")
                 await desk.move_to_standing()
-            elif (data == b"d\n"):
+            elif data == b"d\n":
                 print("move_to_sitting")
                 await desk.move_to_sitting()
-            elif (data == b"r\n"):
+            elif data == b"r\n":
                 print("press_raise")
                 await desk.press_raise()
-            elif (data == b"l\n"):
+            elif data == b"l\n":
                 print("press_lower")
                 await desk.press_lower()
-            elif (data == b"h\n"):
+            elif data == b"h\n":
                 print_command_options()
-            elif (data == b"e\n"):
+            elif data == b"e\n":
                 print("exit")
                 break
 
         await desk.stop_notify()
         print(f"Height: {desk.height} in")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/uplift/__init__.py
+++ b/uplift/__init__.py
@@ -14,35 +14,59 @@ import time
 
 from .utils import height_conv_to_in
 
-_primary_service_uuid_for_discovery  = normalize_uuid_16(0xfe60)
+# --- Service UUIDs ---
+# The block FE60 is allocated to Lierda Science & Technology Group Co., Ltd.
+_service_vendor_discovery = normalize_uuid_16(0xFE60)
 
-_desk_height_uuid = normalize_uuid_16(0xfe62)
-_desk_control_uuid = normalize_uuid_16(0xfe61)
+# --- Characteristic UUIDs ---
+# Generic Access characteristic that stores the device name.
+_char_std_device_name = normalize_uuid_16(0x2A00)
+# Write+Notify. The desk firmware uses this internally to derive its device name.
+_char_vendor_desk_name = normalize_uuid_16(0xFE63)
+# Read+Notify. The desk pushes its current height measurements over this characteristic,
+_char_vendor_desk_height = normalize_uuid_16(0xFE62)
+# Write. All desk commands (wake, sit-preset, stand-preset, raise, lower, request status) are sent as 6-byte payloads.
+_char_vendor_desk_control = normalize_uuid_16(0xFE61)
 
-_wake_uuid = [0xf1, 0xf1, 0x00, 0x00, 0x00, 0x7e] # The content of this command actually doesn't seem to matter, the desk just needs to wake up
-_sit_preset_uuid = [0xf1, 0xf1, 0x05, 0x00, 0x05, 0x7e]
-_stand_preset_uuid = [0xf1, 0xf1, 0x06, 0x00, 0x06, 0x7e]
-_raise_button_uuid = [0xf1, 0xf1, 0x01, 0x00, 0x01, 0x7e]
-_lower_button_uuid = [0xf1, 0xf1, 0x02, 0x00, 0x02, 0x7e]
-_status_uuid = [0xf1, 0xf1, 0x07, 0x00, 0x07, 0x7e]
+# --- Command Payloads ---
+_cmd_wake = [
+    0xF1,
+    0xF1,
+    0x00,
+    0x00,
+    0x00,
+    0x7E,
+]  # The content of this command actually doesn't seem to matter, the desk just needs to wake up
+_cmd_vendor_preset_sit = [0xF1, 0xF1, 0x05, 0x00, 0x05, 0x7E]
+_cmd_vendor_preset_stand = [0xF1, 0xF1, 0x06, 0x00, 0x06, 0x7E]
+_cmd_vendor_button_raise = [0xF1, 0xF1, 0x01, 0x00, 0x01, 0x7E]
+_cmd_vendor_button_lower = [0xF1, 0xF1, 0x02, 0x00, 0x02, 0x7E]
+_cmd_vendor_status = [0xF1, 0xF1, 0x07, 0x00, 0x07, 0x7E]
 
 _scanner_timeout = 10.0
+
 
 def discover(scanner: BleakScanner = None) -> list[BLEDevice]:
     if scanner is None:
         scanner = BleakScanner()
-    
-    return scanner.discover(timeout=_scanner_timeout, service_uuids=[_primary_service_uuid_for_discovery])
+
+    return scanner.discover(
+        timeout=_scanner_timeout, service_uuids=[_service_vendor_discovery]
+    )
+
 
 class Desk:
-    def __init__(self, address: str, name: str, bleak_client: BleakClient = None) -> Self:
+    def __init__(
+        self, address: str, name: str, bleak_client: BleakClient = None
+    ) -> Self:
         self.address = address
         self.name = name
         self._height: float = 0.0
         self.bleak_client = bleak_client
         self._moving = False
         self._last_heights = []
-        self._height_notification_callbacks: list[callable] = []
+        self._notification_callbacks_desk_name: list[callable] = []
+        self._notification_callbacks_height: list[callable] = []
 
     @property
     def height(self):
@@ -59,103 +83,172 @@ class Desk:
     async def move_to_standing(self, bleak_client: BleakClient = None) -> None:
         client = bleak_client or self.bleak_client
 
-        if (client is None):
+        if client is None:
             raise Exception("No bleak client provided")
-        
+
         await self._awaken(client)
-        await client.write_gatt_char(_desk_control_uuid, _stand_preset_uuid, False)
+        await client.write_gatt_char(
+            _char_vendor_desk_control, _cmd_vendor_preset_stand, False
+        )
 
     async def move_to_sitting(self, bleak_client: BleakClient = None) -> None:
         client = bleak_client or self.bleak_client
 
-        if (client is None):
+        if client is None:
             raise Exception("No bleak client provided")
-        
+
         await self._awaken(client)
-        await client.write_gatt_char(_desk_control_uuid, _sit_preset_uuid, False)
+        await client.write_gatt_char(
+            _char_vendor_desk_control, _cmd_vendor_preset_sit, False
+        )
 
     async def press_raise(self, bleak_client: BleakClient = None) -> None:
         client = bleak_client or self.bleak_client
 
-        if (client is None):
+        if client is None:
             raise Exception("No bleak client provided")
-        
+
         await self._awaken(client)
-        await client.write_gatt_char(_desk_control_uuid, _raise_button_uuid, False)
+        await client.write_gatt_char(
+            _char_vendor_desk_control, _cmd_vendor_button_raise, False
+        )
 
     async def press_lower(self, bleak_client: BleakClient = None) -> None:
         client = bleak_client or self.bleak_client
 
-        if (client is None):
+        if client is None:
             raise Exception("No bleak client provided")
-        
+
         await self._awaken(client)
-        await client.write_gatt_char(_desk_control_uuid, _lower_button_uuid, False)
+        await client.write_gatt_char(
+            _char_vendor_desk_control, _cmd_vendor_button_lower, False
+        )
 
     async def start_notify(self, bleak_client: BleakClient = None) -> None:
         client = bleak_client or self.bleak_client
 
-        if (client is None):
+        if client is None:
             raise Exception("No bleak client provided")
-        
-        await client.start_notify(_desk_height_uuid, self._height_notify_callback)
+
+        await client.start_notify(
+            _char_vendor_desk_name, self._notify_callback_desk_name
+        )
+        await client.start_notify(
+            _char_vendor_desk_height, self._notify_callback_height
+        )
 
     async def stop_notify(self, bleak_client: BleakClient = None) -> None:
         client = bleak_client or self.bleak_client
 
-        if (client is None):
+        if client is None:
             raise Exception("No bleak client provided")
-        
+
         try:
-            await client.stop_notify(_desk_height_uuid)
+            await client.stop_notify(_char_vendor_desk_height)
         except BleakDBusError:
             pass
+
+    async def read_device_name(self, bleak_client: BleakClient = None):
+        client = bleak_client or self.bleak_client
+
+        if client is None:
+            raise Exception("No bleak client provided")
+
+        data = await client.read_gatt_char(_char_std_device_name)
+        name = data.decode("utf-8", errors="ignore")
+        print("Device name is:", name)
+        return name
+
+    async def write_desk_name(
+        self, bleak_client: BleakClient = None, desk_name=None
+    ) -> float:
+        client = bleak_client or self.bleak_client
+
+        if client is None:
+            raise Exception("No bleak client provided")
+
+        if desk_name is None:
+            raise Exception("No desk_name provided")
+
+        name_bytes = desk_name.encode("utf-8")
+        header = bytes([0x01, 0xFC, 0x07, len(name_bytes)])
+        packet = header + name_bytes
+
+        print(f"Setting desk name: {desk_name}")
+        self._last_action_time = time.time()
+        await client.write_gatt_char(_char_vendor_desk_name, packet, False)
 
     async def read_height(self, bleak_client: BleakClient = None) -> float:
         client = bleak_client or self.bleak_client
 
-        if (client is None):
+        if client is None:
             raise Exception("No bleak client provided")
-        
+
         self._last_action_time = time.time()
-        await client.write_gatt_char(_desk_control_uuid, _status_uuid, False)
-        self._height = height_conv_to_in(await client.read_gatt_char(_desk_height_uuid))
+        await client.write_gatt_char(
+            _char_vendor_desk_control, _cmd_vendor_status, False
+        )
+        self._height = height_conv_to_in(
+            await client.read_gatt_char(_char_vendor_desk_height)
+        )
         return self.height
 
-    def register_callback(self, callback: callable) -> None:
-        self._height_notification_callbacks.append(callback)
+    def register_callback_desk_name(self, callback: callable) -> None:
+        self._notification_callbacks_desk_name.append(callback)
 
-    def deregister_callback(self, callable: callable) -> None:
-        self._height_notification_callbacks.remove(callback)
+    def deregister_callback_desk_name(self, callback: callable) -> None:
+        self._notification_callbacks_desk_name.remove(callback)
+
+    def register_callback_height(self, callback: callable) -> None:
+        self._notification_callbacks_height.append(callback)
+
+    def deregister_callback_height(self, callback: callable) -> None:
+        self._notification_callbacks_height.remove(callback)
 
     def __str__(self):
         return f"{self.name} - {self.address}"
 
-    async def _height_notify_callback(self, sender: BleakGATTCharacteristic, data: bytearray):
+    async def _notify_callback_desk_name(
+        self, sender: BleakGATTCharacteristic, data: bytearray
+    ):
+        # Anecdotally, the returned data is an ACK with a structure like:
+        # - 0x04 - A length field indicating 4 bytes follow
+        # - 0xFC, 0x07 - The write command opcode; the same as was sent in the write command header
+        # - 0x01 - A "success" status code
+        # - 0x00 - A checksum or zero-padding
+        for callback in self._notification_callbacks_desk_name:
+            await callback(self)
+
+    async def _notify_callback_height(
+        self, sender: BleakGATTCharacteristic, data: bytearray
+    ):
         self._height = height_conv_to_in(data)
 
-        if (len(self._last_heights) > 0 and self._last_heights[-1] != self._height):
+        if len(self._last_heights) > 0 and self._last_heights[-1] != self._height:
             self._set_moving(True)
 
         self._last_heights.append(self._height)
         if len(self._last_heights) > 4:
-            if (self.moving
-                and self._last_action_time + 1 < time.time() # Only set moving to false if we've been moving for more than 1 second (sometimes the first few height updates are the same)
-                and self._last_heights[0] == self._height 
+            if (
+                self.moving
+                and self._last_action_time + 1
+                < time.time()  # Only set moving to false if we've been moving for more than 1 second (sometimes the first few height updates are the same)
+                and self._last_heights[0] == self._height
                 and self._last_heights[1] == self._height
                 and self._last_heights[2] == self._height
-                and self._last_heights[3] == self._height):
+                and self._last_heights[3] == self._height
+            ):
                 self._set_moving(False)
 
             self._last_heights.pop(0)
-        
-        for callback in self._height_notification_callbacks:
+
+        for callback in self._notification_callbacks_height:
             await callback(self)
 
     async def _awaken(self, bleak_client: BleakClient = None) -> None:
         client = bleak_client or self.bleak_client
 
-        if (client is None):
+        if client is None:
             raise Exception("No bleak client provided")
 
-        await bleak_client.write_gatt_char(_desk_control_uuid, _wake_uuid, False)
+        await bleak_client.write_gatt_char(_char_vendor_desk_control, _cmd_wake, False)


### PR DESCRIPTION
This commit changes the following:
- Adds support for changing the desk name via `write_desk_name`
- Adds "n" and "w" to the demo to read and write the device name
- Renames the service/characteristic/cmd vars to reduce confusion
- Adds initial logging to the demo to make it clear it's not hanging

There exists a vendor characteristic 0xFE63 that supports writing the desk name. The characteristic is Write+Notify, although the notification appears to be an ack and doesn't contain the updated desk name. But the update is observable by reading the standard (i.e., non-vendor-specific) characteristic 0x2A00 that returns the BLE device name.

Note that the naming is confusing but deliberate: desk_name corresponds to the vendor-specific desk_name, which is used by the BLE firmware to derive the standard device_name. This is why I've called the functions `write_desk_name` and `read_device_name`.

Further, I renamed the variables for the various services, characteristics, and commands. Specifically, calling the commands "uuids" was really confusing since they're just payload bytes in characteristics. And the words std vs vendor now differentiate between standard and vendor-specific services and characteristics.

I also renamed the height callback variables to make it more extensible, as this PR introduces the ability to register callbacks for when the desk_name is changed.